### PR TITLE
Fix contract to allow optional file list

### DIFF
--- a/private/dotenv.rkt
+++ b/private/dotenv.rkt
@@ -5,7 +5,8 @@
 (provide
  (contract-out
   [dotenv-read (-> (listof string?) environment-variables?)]
-  [dotenv-load! (-> (listof string?) (listof boolean?))]))
+  [dotenv-load! (case-> (-> (listof string?) (listof boolean?))
+                        (-> (listof boolean?)))]))
 
 (define (ignorable-line? line)
   (or 


### PR DESCRIPTION
This uses `case->` to allow the 0-argument version of `dotenv-load!`.